### PR TITLE
v1.1.4

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -54,7 +54,7 @@ func trimSrcPath(s string) string {
 func trimDirs(s string) string {
 	r := []rune(s)
 	for i := len(r) - 1; i > 0; i-- {
-		if r[i] == os.PathSeparator {
+		if r[i] == '/' || r[i] == os.PathSeparator {
 			return string(r[i+1:])
 		}
 	}


### PR DESCRIPTION
- separate by slash if separator is not os.PathSeparator in trimDirs