### PR TITLE
v2.0.0

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -77,6 +77,11 @@ func (l *Logger) out(severity Severity, message string, err error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
+	switch severity {
+	case severityPrint:
+		severity = l.printSeverity
+	}
+
 	if l.output == nil {
 		return
 	}
@@ -243,26 +248,17 @@ func (l *Logger) Debugln(args ...interface{}) {
 
 // Print logs a log which has the underlying Logger's print severity.
 func (l *Logger) Print(args ...interface{}) {
-	if l == nil {
-		return
-	}
-	l.log(l.printSeverity, args...)
+	l.log(severityPrint, args...)
 }
 
 // Printf logs a log which has the underlying Logger's print severity.
 func (l *Logger) Printf(format string, args ...interface{}) {
-	if l == nil {
-		return
-	}
-	l.logf(l.printSeverity, format, args...)
+	l.logf(severityPrint, format, args...)
 }
 
 // Println logs a log which has the underlying Logger's print severity.
 func (l *Logger) Println(args ...interface{}) {
-	if l == nil {
-		return
-	}
-	l.logln(l.printSeverity, args...)
+	l.logln(severityPrint, args...)
 }
 
 // SetOutput sets the underlying Logger's output.
@@ -306,14 +302,14 @@ func (l *Logger) SetVerbose(verbose Verbose) *Logger {
 }
 
 // SetPrintSeverity sets the underlying Logger's severity level which is using with Print methods.
-// If printSeverity is invalid, it sets SeverityInfo.
+// If printSeverity is invalid or, less or equal than SeverityFatal; it sets SeverityInfo.
 // It returns the underlying Logger.
 // By default, SeverityInfo.
 func (l *Logger) SetPrintSeverity(printSeverity Severity) *Logger {
 	if l == nil {
 		return nil
 	}
-	if !printSeverity.IsValid() {
+	if !printSeverity.IsValid() || printSeverity <= SeverityFatal {
 		printSeverity = SeverityInfo
 	}
 	l.mu.Lock()

--- a/logger.go
+++ b/logger.go
@@ -119,7 +119,7 @@ func (l *Logger) out(severity Severity, message string, err error) {
 	if includeStackTrace {
 		pcSize = l.stackTracePCSize
 	}
-	pc := programCounters(pcSize, 5)
+	pc := getProgramCounters(pcSize, 5)
 	st := NewStackTrace(pc)
 
 	if st.SizeOfCallers() > 0 {

--- a/logger.go
+++ b/logger.go
@@ -17,7 +17,7 @@ type Logger struct {
 	verbose            Verbose
 	printSeverity      Severity
 	stackTraceSeverity Severity
-	stackTracePCSize   int
+	stackTraceSize     int
 	verbosity          Verbose
 	time               *time.Time
 	prefix             string
@@ -37,7 +37,7 @@ func NewLogger(output Output, severity Severity, verbose Verbose) *Logger {
 		verbose:            verbose,
 		printSeverity:      SeverityInfo,
 		stackTraceSeverity: SeverityNone,
-		stackTracePCSize:   64,
+		stackTraceSize:     64,
 	}
 }
 
@@ -54,7 +54,7 @@ func (l *Logger) Clone() *Logger {
 		verbose:            l.verbose,
 		printSeverity:      l.printSeverity,
 		stackTraceSeverity: l.stackTraceSeverity,
-		stackTracePCSize:   l.stackTracePCSize,
+		stackTraceSize:     l.stackTraceSize,
 		verbosity:          l.verbosity,
 		time:               nil,
 		prefix:             l.prefix,
@@ -115,11 +115,11 @@ func (l *Logger) out(severity Severity, message string, err error) {
 
 	includeStackTrace := l.stackTraceSeverity >= severity
 
-	pcSize := 1
+	stSize := 1
 	if includeStackTrace {
-		pcSize = l.stackTracePCSize
+		stSize = l.stackTraceSize
 	}
-	st := CurrentStackTrace(pcSize, 5)
+	st := CurrentStackTrace(stSize, 5)
 
 	if st.SizeOfCallers() > 0 {
 		log.StackCaller = st.Caller(0)
@@ -339,20 +339,20 @@ func (l *Logger) SetStackTraceSeverity(stackTraceSeverity Severity) *Logger {
 	return l
 }
 
-// SetStackTracePCSize sets the maximum program counter size of the stack trace for the underlying Logger.
-// If stackTracePCSize is out of range, it sets 64. The range is 1 to 16384 each included.
+// SetStackTraceSize sets the maximum program counter size of the stack trace for the underlying Logger.
+// If stackTraceSize is out of range, it sets 64. The range is 1 to 16384 each included.
 // It returns the underlying Logger.
 // By default, 64.
-func (l *Logger) SetStackTracePCSize(stackTracePCSize int) *Logger {
+func (l *Logger) SetStackTraceSize(stackTraceSize int) *Logger {
 	if l == nil {
 		return nil
 	}
-	if 1 > stackTracePCSize || stackTracePCSize > 16384 {
-		stackTracePCSize = 64
+	if 1 > stackTraceSize || stackTraceSize > 16384 {
+		stackTraceSize = 64
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.stackTracePCSize = stackTracePCSize
+	l.stackTraceSize = stackTraceSize
 	return l
 }
 

--- a/logger.go
+++ b/logger.go
@@ -119,8 +119,7 @@ func (l *Logger) out(severity Severity, message string, err error) {
 	if includeStackTrace {
 		pcSize = l.stackTracePCSize
 	}
-	pc := getProgramCounters(pcSize, 5)
-	st := NewStackTrace(pc)
+	st := CurrentStackTrace(pcSize, 5)
 
 	if st.SizeOfCallers() > 0 {
 		log.StackCaller = st.Caller(0)

--- a/logng.go
+++ b/logng.go
@@ -113,17 +113,17 @@ func Debugln(args ...interface{}) {
 
 // Print logs a log which has the default Logger's print severity to the default Logger.
 func Print(args ...interface{}) {
-	defaultLogger.log(defaultLogger.printSeverity, args...)
+	defaultLogger.log(severityPrint, args...)
 }
 
 // Printf logs a log which has the default Logger's print severity to the default Logger.
 func Printf(format string, args ...interface{}) {
-	defaultLogger.logf(defaultLogger.printSeverity, format, args...)
+	defaultLogger.logf(severityPrint, format, args...)
 }
 
 // Println logs a log which has the default Logger's print severity to the default Logger.
 func Println(args ...interface{}) {
-	defaultLogger.logln(defaultLogger.printSeverity, args...)
+	defaultLogger.logln(severityPrint, args...)
 }
 
 // SetOutput sets the default Logger's output.

--- a/logng.go
+++ b/logng.go
@@ -14,7 +14,7 @@ func Reset() {
 	SetVerbose(0)
 	SetPrintSeverity(SeverityInfo)
 	SetStackTraceSeverity(SeverityNone)
-	SetStackTracePCSize(64)
+	SetStackTraceSize(64)
 	SetTextOutputWriter(defaultTextOutputWriter)
 	SetTextOutputFlags(TextOutputFlagDefault)
 }
@@ -164,12 +164,12 @@ func SetStackTraceSeverity(stackTraceSeverity Severity) *Logger {
 	return defaultLogger.SetStackTraceSeverity(stackTraceSeverity)
 }
 
-// SetStackTracePCSize sets the maximum program counter size of the stack trace for the default Logger.
-// If stackTracePCSize is out of range, it sets 64. The range is 1 to 16384 each included.
+// SetStackTraceSize sets the maximum program counter size of the stack trace for the default Logger.
+// If stackTraceSize is out of range, it sets 64. The range is 1 to 16384 each included.
 // It returns the default Logger.
 // By default, 64.
-func SetStackTracePCSize(stackTracePCSize int) *Logger {
-	return defaultLogger.SetStackTracePCSize(stackTracePCSize)
+func SetStackTraceSize(stackTraceSize int) *Logger {
+	return defaultLogger.SetStackTraceSize(stackTraceSize)
 }
 
 // V clones the default Logger with the given verbosity if the default Logger's verbose is greater or equal to the given verbosity, otherwise returns nil.

--- a/severity.go
+++ b/severity.go
@@ -93,3 +93,8 @@ func (s *Severity) UnmarshalText(text []byte) error {
 	}
 	return nil
 }
+
+// custom severities
+const (
+	severityPrint Severity = -iota - 1
+)

--- a/stack.go
+++ b/stack.go
@@ -82,13 +82,27 @@ type StackTrace struct {
 	callers         []StackCaller
 }
 
-// NewStackTrace creates a new StackTrace.
+// NewStackTrace creates a new StackTrace from program counters.
 func NewStackTrace(programCounters []uintptr) *StackTrace {
+	pc := make([]uintptr, len(programCounters))
+	copy(pc, programCounters)
+	return newStackTrace(pc)
+}
+
+// CurrentStackTrace creates a new StackTrace at this point.
+// It uses runtime.Callers and uses skip arguments as is. So you should increase skip argument by 1.
+func CurrentStackTrace(size, skip int) *StackTrace {
+	pc := make([]uintptr, size)
+	pc = pc[:runtime.Callers(skip, pc)]
+	return newStackTrace(pc)
+}
+
+// newStackTrace creates a new StackTrace from program counters without copying.
+func newStackTrace(programCounters []uintptr) *StackTrace {
 	t := &StackTrace{
-		programCounters: make([]uintptr, len(programCounters)),
+		programCounters: programCounters,
 		callers:         make([]StackCaller, 0, len(programCounters)),
 	}
-	copy(t.programCounters, programCounters)
 	if len(t.programCounters) > 0 {
 		frames := runtime.CallersFrames(t.programCounters)
 		for {

--- a/stack.go
+++ b/stack.go
@@ -90,7 +90,8 @@ func NewStackTrace(programCounters []uintptr) *StackTrace {
 }
 
 // CurrentStackTrace creates a new StackTrace at this point.
-// It uses runtime.Callers and uses skip arguments as is. So you should increase skip argument by 1.
+// size limits maximum program counter size.
+// It uses runtime.Callers and uses skip argument as is. So you should increase skip argument by 1.
 func CurrentStackTrace(size, skip int) *StackTrace {
 	pc := make([]uintptr, size)
 	pc = pc[:runtime.Callers(skip, pc)]

--- a/utils.go
+++ b/utils.go
@@ -2,20 +2,12 @@ package logng
 
 import (
 	"fmt"
-	"runtime"
 )
 
 // wrappedError is an interface to simulate GoLang's wrapped errors.
 type wrappedError interface {
 	error
 	Unwrap() error
-}
-
-// getProgramCounters returns program counters by using runtime.Callers.
-func getProgramCounters(size, skip int) []uintptr {
-	pc := make([]uintptr, size)
-	pc = pc[:runtime.Callers(skip, pc)]
-	return pc
 }
 
 func itoa(buf *[]byte, i int, wid int) {

--- a/utils.go
+++ b/utils.go
@@ -11,8 +11,8 @@ type wrappedError interface {
 	Unwrap() error
 }
 
-// programCounters returns program counters by using runtime.Callers.
-func programCounters(size, skip int) []uintptr {
+// getProgramCounters returns program counters by using runtime.Callers.
+func getProgramCounters(size, skip int) []uintptr {
 	pc := make([]uintptr, size)
 	pc = pc[:runtime.Callers(skip, pc)]
 	return pc


### PR DESCRIPTION
- SetStackTracePCSize is renamed to SetStackTraceSize
- fix: race conditions on print severity.
- implementation of custom severities.
- don't allow SevertiyFatal for Print